### PR TITLE
♻️Refactor: 카카오 로그인 콜백 수정

### DIFF
--- a/src/auth/auth.route.js
+++ b/src/auth/auth.route.js
@@ -7,7 +7,10 @@ const router = express.Router();
 // 카카오 로그인 시작
 router.get('/kakao', authController.kakaoLogin);
 
-// 카카오 콜백
+// 카카오 콜백 - 프론트에서 POST로 code 전송받음
+router.post('/oauth2/callback/kakao', authController.kakaoCallbackHandler);
+
+// 테스트용 GET 방식도 추가 (임시)
 router.get('/oauth2/callback/kakao', authController.kakaoCallbackHandler);
 
 // 로그아웃

--- a/src/auth/auth.service.js
+++ b/src/auth/auth.service.js
@@ -31,7 +31,7 @@ class AuthService {
         }
     }
 
-    // 카카오 로그인 처리
+    // 카카오 로그인 처리 - 토큰과 사용자 정보 모두 반환
     async handleKakaoLogin(profile) {
         try {
             const email = profile._json.kakao_account?.email;
@@ -50,7 +50,10 @@ class AuthService {
                 imageUrl
             });
 
-            return this.generateTokens(user);
+            const tokens = this.generateTokens(user);
+
+            // 토큰과 사용자 정보 모두 반환
+            return { tokens, user };
         } catch (error) {
             throw error;
         }


### PR DESCRIPTION
## 📌 PR 요약
- 유저 정보 반환
- 콜백 주소 수정

## ✅ 체크리스트
- [x] 기능 구현 완료
- [x] 테스트 완료
- [x] Swagger 문서 작성
- [x] 관련 이슈에 연결

## 📎 참고 링크
- https://github.com/WE-EMS/backend/issues/18


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Kakao OAuth callback via POST, while retaining a test-friendly GET endpoint.
  - Callback now accepts authorization codes from either POST body or GET query.
  - Automatic redirect URI selection based on environment (production vs. local).

- Improvements
  - Response now includes accessToken and an expiresAt timestamp (7 days).
  - Consistent, structured error responses for missing code (400) and failures (500).

- Documentation
  - Updated API docs with clearer descriptions, examples, and error schemas for the Kakao callback endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->