### PR TITLE
🐛Fix: 시간 오차

### DIFF
--- a/src/auth/auth.controller.js
+++ b/src/auth/auth.controller.js
@@ -475,8 +475,8 @@ import { AuthResponseDto } from "./dto/auth.response.dto.js";
 // 로컬 개발용
 const cookieOptsDev = {
     httpOnly: true,
-    secure: false,    // http
-    sameSite: 'Lax',  // 같은 PC 포트 간 요청만
+    secure: true,    // http
+    sameSite: 'None',  // 같은 PC 포트 간 요청만
     path: '/',
     maxAge: 7 * 24 * 60 * 60 * 1000,
 };

--- a/src/helps/dto/helps.request.dto.js
+++ b/src/helps/dto/helps.request.dto.js
@@ -48,11 +48,14 @@ export class CreateHelpRequestDto {
         if (!this.serviceDate) {
             errors.push('서비스 날짜를 선택해주세요.');
         } else {
-            const serviceDate = new Date(this.serviceDate);
-            const today = new Date();
-            today.setHours(0, 0, 0, 0);
-
-            if (serviceDate < today) {
+            // KST 기준으로 비교 → utils/time.js에서 헬퍼 불러와 사용
+            // - toKstDateOnly: DB/입력 날짜를 KST 날짜 객체로 변환
+            // - getKstStartOfTodayUtc: 오늘 00:00(KST)의 UTC (여기선 단순히 KST '오늘 00:00'을 만들어 비교)
+            const kstNow = new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Seoul" }));
+            kstNow.setHours(0, 0, 0, 0); // 오늘 KST 자정
+            const serviceDateKst = new Date(new Date(this.serviceDate).toLocaleString("en-US", { timeZone: "Asia/Seoul" }));
+            serviceDateKst.setHours(0, 0, 0, 0);
+            if (serviceDateKst < kstNow) {
                 errors.push('서비스 날짜는 오늘 또는 이후여야 합니다.');
             }
         }

--- a/src/helps/helps.controller.js
+++ b/src/helps/helps.controller.js
@@ -794,7 +794,7 @@ export class HelpsController {
  *         schema:
  *           type: integer
  *           enum: [0, 1, 2]
- *         description: "매칭 상태 (0: 요청, 1: 배정, 2: 완료, 4: 모집종료)"
+ *         description: "매칭 상태 (0: 요청, 1: 배정, 2: 완료)"
  *       - in: query
  *         name: helpTypes
  *         schema:

--- a/src/helps/helps.repository.js
+++ b/src/helps/helps.repository.js
@@ -287,6 +287,26 @@ export class HelpsRepository {
             data: { status: 4, updatedAt: new Date() }
         });
     }
+
+    // 과거 날짜 → 모집종료(4) 처리
+    async closeExpiredByPastDate(todayStartUtc) {
+        return prisma.helpRequest.updateMany({
+            where: { status: 0, serviceDate: { lt: todayStartUtc } },
+            data: { status: 4, updatedAt: new Date() },
+        });
+    }
+
+    // (B) 오늘 + 시작시간 경과 → 모집종료(4) 처리
+    async closeExpiredByStartTimeToday({ todayStartUtc, tomorrowStartUtc, nowUtcTime }) {
+        return prisma.helpRequest.updateMany({
+            where: {
+                status: 0,
+                serviceDate: { gte: todayStartUtc, lt: tomorrowStartUtc }, // 오늘(KST)
+                startTime: { lte: nowUtcTime },                             // time-only(UTC) 비교
+            },
+            data: { status: 4, updatedAt: new Date() },
+        });
+    }
 }
 
 export const helpsRepository = new HelpsRepository();

--- a/src/jobs/close-expired-helps.job.js
+++ b/src/jobs/close-expired-helps.job.js
@@ -1,34 +1,20 @@
 import cron from "node-cron";
 import { helpsRepository } from "../helps/helps.repository.js";
+import { kstStartOfTodayAsUtc, kstStartOfTomorrowAsUtc, nowUtcTimeOfDayEpoch } from "../utils/time.js";
 
-/**
- * 오늘의 "KST 자정(00:00)" 시각을 UTC Date 객체로 변환
- * - DB의 serviceDate 비교 기준으로 사용
- * - 예: 2025-09-06 00:00:00 (KST) → 2025-09-05 15:00:00 (UTC)
- */
-function kstStartOfTodayAsUtc() {
-    const now = new Date();
-    // 현재 시간을 KST로 변환
-    const kstNow = new Date(now.toLocaleString("en-US", { timeZone: "Asia/Seoul" }));
-    kstNow.setHours(0, 0, 0, 0); // KST 자정으로 맞춤
-    // KST → UTC 변환 (9시간 빼기)
-    return new Date(kstNow.getTime() - 9 * 60 * 60 * 1000);
-}
-
-/**
- * 모집종료(4) 상태 업데이트 스케줄러
- * - 서버 시작 시 즉시 1회 실행
- * - 이후 매 30분마다 실행
- */
 export function scheduleCloseExpiredHelps() {
     const run = async () => {
-        const cutoffUtc = kstStartOfTodayAsUtc();
-        const result = await helpsRepository.closeExpiredHelps(cutoffUtc);
-        console.log(
-            `[closeExpiredHelps] ${new Date().toISOString()} - updated ${result.count} rows`
-        );
+        const todayStartUtc = kstStartOfTodayAsUtc();
+        const tomorrowStartUtc = kstStartOfTomorrowAsUtc();
+        const nowUtcTime = nowUtcTimeOfDayEpoch();
+
+        await helpsRepository.closeExpiredByPastDate(todayStartUtc);
+        await helpsRepository.closeExpiredByStartTimeToday({
+            todayStartUtc, tomorrowStartUtc, nowUtcTime
+        });
+        // console.log(`[closeExpiredHelps/update] past=${r1.count}, todayPastStart=${r2.count}`);
     };
 
-    run(); // 서버 시작 시 즉시 1회 실행
-    cron.schedule("*/30 * * * *", run, { timezone: "Asia/Seoul" }); // 30분마다 실행
+    run(); // 서버 시작 시 즉시 실행
+    cron.schedule("*/30 * * * *", run, { timezone: "Asia/Seoul" });
 }

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -1,0 +1,21 @@
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+/** 오늘 KST 00:00을 UTC Date로 반환 */
+export function kstStartOfTodayAsUtc() {
+    const nowUtcMs = Date.now();
+    const nowKst = new Date(nowUtcMs + KST_OFFSET_MS);
+    nowKst.setHours(0, 0, 0, 0);
+    return new Date(nowKst.getTime() - KST_OFFSET_MS);
+}
+
+/** 내일 KST 00:00을 UTC Date로 반환 */
+export function kstStartOfTomorrowAsUtc() {
+    const t = kstStartOfTodayAsUtc();
+    return new Date(t.getTime() + 24 * 60 * 60 * 1000);
+}
+
+/** 현재 시간을 UTC time-only(1970-01-01 기준)로 반환 */
+export function nowUtcTimeOfDayEpoch() {
+    const now = new Date();
+    return new Date(Date.UTC(1970, 0, 1, now.getUTCHours(), now.getUTCMinutes(), now.getUTCSeconds()));
+}


### PR DESCRIPTION
## 📌 PR 요약
- 리스트 조회시 UTC-KST 시간 오차 해결

## ✅ 체크리스트
- [x] 기능 구현 완료
- [x] 테스트 완료
- [x] Swagger 문서 작성
- [x] 관련 이슈에 연결

## 📎 참고 링크
- #78 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Service date validation now uses Korea Standard Time to prevent unintended past-date rejections.
  * Expired help requests auto-close more accurately during the day, reducing stale listings.

* **Documentation**
  * Updated status parameter description for the help list endpoint to reflect supported values.

* **Chores**
  * Development cookies now use Secure and SameSite=None for production parity, improving sign-in reliability during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->